### PR TITLE
Remove unused safe_acos macro

### DIFF
--- a/main.glsl
+++ b/main.glsl
@@ -18,7 +18,6 @@ const float constant2_FON = 2.0f / 3.0f - 28.0f / (15.0f * pi);
 // FON directional albedo (analytic)
 float E_FON_exact(float mu, float r)
 {
-    #define safe_acos(x) (acos(clamp(x, -1.0, 1.0)))
     float AF = 1.0f / (1.0f + constant1_FON * r); // FON $A$ coeff.
     float BF = r * AF;                            // FON $B$ coeff.
     float Si = sqrt(1.0f - (mu * mu));


### PR DESCRIPTION
The `safe_acos` macro is unused because the `clamp` that it performs is inlined into the code. If a clamped `acos` were done in multiple places it might make sense to keep the macro (potentially changing it to a function and updating it to use `f` suffixes on the float literals so it can be compiled as C++ without type mismatches), however it's only done in once place.